### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ be specified.
 * `path`: *Optional.* Path to the application to push. If this isn't set then
   it will be read from the manifest instead.
 * `environment_variables`: *Optional.* It is not necessary to set the variables in [manifest][cf-manifests] if this parameter is set.
-* `vars`: *Optional.* Map of variables to pass to manifest
+* `vars`: *Optional.* Map of variables to pass to manifest. If you user more than one word which is passed to manifest, put the underscore between them (example: "environment_variable")
 * `vars_files`: *Optional.* List of variables files to pass to manifest
 * `no_start`: *Optional.* Deploys the app but does not start it. This parameter is ignored when `current_app_name` is specified.
 * `debug`: *Optional.* TO enable debug output.


### PR DESCRIPTION
In my pipeline, I'm using the docker image from arvacims/cf-resource-sso.

- put: cloud-foundry
        params:
          manifest: manifest.yml
          path: *some path*
          debug: true
          vars:
            environment-variable: ((env-var))
            example-data: ((example-value))
            example1-data1: ((example1-value1))

I got the next error:
mode of '/tmp/cf_temp_exec.ioNhDi' changed to 0711 (rwx--x--x)
path to upload: *some path*
jq: error: data/0 is not defined at <top-level>, line 1:
.params.vars.example-data // ""                     
jq: 1 compile error
jq: error: data1/0 is not defined at <top-level>, line 1:
.params.vars.example1-data1 // ""                     
jq: 1 compile error
jq: error: variable/0 is not defined at <top-level>, line 1:
.params.vars.environment-variable // ""                     
jq: 1 compile error
/tmp/cf_temp_exec.ioNhDi
#!/bin/bash
exec cf push -f e2ed-libs/manifest.yml -p e2ed-libs/e2ed-ia-modm-*.jar --var "environment-variable=" --var "example-data=" --var "example1-data1="
Incorrect Usage: invalid argument for flag `--var' (expected []template.VarKV): Expected var 'environment-variable=' to specify non-empty value

When i changed to the names with underscore ("environment-variable" ----> "environment_variable") it all worked.

Maybe to update the readme that "-" are not allowed?